### PR TITLE
Create product modal view

### DIFF
--- a/deals-add.js
+++ b/deals-add.js
@@ -100,7 +100,7 @@ $(function () {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
 			}
 		},
-
+		/*
 		addCardRow: function () {
 			let l = 0;
 			for (l = 0; l > 4; l++) {
@@ -112,7 +112,7 @@ $(function () {
 			for (k = $('.deal-card').length; k > ($('.deal-card').length - 4); k--) {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
 			}
-		},
+		},*/
 		/**
 		* Prevents background scrolling on desktop
 		*/
@@ -206,7 +206,6 @@ $(function () {
 			// there will already be one card on the page, so for subsequent data entries, create a card before populating
 			if (cardNumber !== 0) {
 				RatesDealsHandler.createNewCard();
-				RatesDealsHandler.removeCardRow();
 			}
 			// make the first card on the page visible
 			$('.deal-card')[0].style.display = "block";
@@ -313,7 +312,6 @@ $(function () {
 					for (cardNumber = Config.offset; dataEntry < response.data.length && Config.hasMore; cardNumber++ , dataEntry++) {
 						RatesDealsHandler.populateDeals(response, cardNumber, dataEntry);
 					}
-					RatesDealsHandler.addCardRow();
 
 					// checks if there are more deals that can be loaded for infinite scroll
 					Config.hasMore = response.hasMore;

--- a/deals-add.js
+++ b/deals-add.js
@@ -356,7 +356,7 @@ $(function () {
 						launchApp: function () {
 							var now = new Date().valueOf();
 							setTimeout(function () {
-									if (new Date().valueOf() - now > 100) return;
+									if (new Date().valueOf() - now > 500) return;
 									RatesDealsHandler.app.openWebApp();
 							}, 25);
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");

--- a/deals-add.js
+++ b/deals-add.js
@@ -285,8 +285,12 @@ $(function () {
 						RatesDealsHandler.populateModal(response);
 
 						// update banner link so that the app opens at product page
-						$(open-app-button)[0].href = "exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ productId;
-						$(open-app-button)[1].href = "exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ productId;
+						$(open-app-button)[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$(open-app-button)[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+
+						// check if ios or android
+						$(install-app-button)[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$(install-app-button)[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 					}
 
 				})

--- a/deals-add.js
+++ b/deals-add.js
@@ -317,15 +317,8 @@ $(function () {
 						// populate data
 						RatesDealsHandler.populateModal(response);
 
-						// make both banners appear
 						$('.top-banner')[0].style.display = "block";
-
-						if ($('.top-banner')[0].style.visibility === 'hidden') {
-							$('.bottom-banner')[0].style.display = "block";
-						} 
-						else {
-							$('.bottom-banner')[0].style.display = "none";
-						}						
+						$('.bottom-banner')[0].style.display = "none";				
 
 						// update banner link so that the app opens at product page
 						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
@@ -405,6 +398,8 @@ $(function () {
 			// check if ios or android
 			$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 			$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+
+			$('.top-banner').style.display = "none";
 		}
 	};
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -356,7 +356,9 @@ $(function () {
 						launchApp: function () {
 							var now = new Date().valueOf();
 							setTimeout(function () {
-									if (new Date().valueOf() - now > 3000) return;
+									if (new Date().valueOf() - now > 3000) {
+										return;
+									}
 									window.location.replace("itms-apps://itunes.apple.com/sg/app/rates-mobile-app-by-ratex/id1350096340?mt=8");
 							}, 25);
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
@@ -370,7 +372,9 @@ $(function () {
 					var app = {
 						launchApp: function () {
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
-							this.timer = setTimeout(this.openWebApp, 1000);
+							setTimeout(function () {
+								RatesDealsHandler.getProductModal(parseInt(qs.productId));
+							}, 25);
 						},
 					};
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -126,6 +126,10 @@ $(function () {
 				$('.error-bg')[0].style.display = "flex";
 			}
 		},
+		/**
+		 * Closes the product modal, update address bar and enable scroll
+		 * make sure only the bottom banner appears if user hasn't already closed it
+		 */
 		handleCloseProductModal: function () {
 			// close modal
 			RatesDealsHandler.toggleModal();
@@ -148,6 +152,9 @@ $(function () {
 			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
 			$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
 		},
+		/**
+		 * Closes the error modal, update the address bar and enable scrolling
+		 */
 		handleCloseErrorModal: function () {
 			// close alert
 			RatesDealsHandler.toggleError();
@@ -158,6 +165,9 @@ $(function () {
 			// Remove listener to disable scroll
 			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
 		},
+		/**
+		 * Check the OS that the user is on and set Config.isAndroid to true if it is detected to not be iOS
+		 */
 		checkOS: function() {
 			const ua = window.navigator.userAgent;
 			const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
@@ -408,9 +418,16 @@ $(function () {
 			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
 			$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
 
-			// check if ios or android
-			$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
-			$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+			// check if ios or android and update link accordingly
+			RatesDealsHandler.checkOS();
+			if(Config.isAndroid) {
+				$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
+				$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
+			}
+			else {
+				$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+				$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+			}
 
 			$('.top-banner').style.display = "none";
 		}

--- a/deals-add.js
+++ b/deals-add.js
@@ -344,48 +344,7 @@ $(function () {
 
 			// check for specified product to display
 			if (qs.productId !== undefined) {
-
-				const ua = window.navigator.userAgent;
-				// Detect if user is on iOS
-				const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
-				const webkit = !!ua.match(/WebKit/i);
-				// Detect if user is currently using safari web browser
-				const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
-				let hasSmartBanner = false;
-				// if yes, check for cookie
-				if (iOSSafari) { // if in safari
-					// hasSmartBanner = window.innerHeight > $(window).innerHeight() - 50;
-					if (window.innerHeight < $(window).innerHeight() - 50) {
-						hasSmartBanner = true;
-					}
-					var app = {
-						launchApp: function () {
-							setTimeout(function () {
-								RatesDealsHandler.getProductModal(parseInt(qs.productId));
-							}, 25);
-							if (!hasSmartBanner) {
-								window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=" + qs.productId);
-							}
-						},
-					};
-
-					app.launchApp();
-				}
-				else if (ua.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/)) { // if in other mobile browsers
-					var app = {
-						launchApp: function () {
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=" + qs.productId);
-							setTimeout(function () {
-								RatesDealsHandler.getProductModal(parseInt(qs.productId));
-							}, 25);
-						},
-					};
-
-					app.launchApp();
-				}
-				else { // if on desktop
-					RatesDealsHandler.getProductModal(parseInt(qs.productId));
-				}
+				RatesDealsHandler.getProductModal(parseInt(qs.productId));
 			}
 		}
 	};

--- a/deals-add.js
+++ b/deals-add.js
@@ -100,10 +100,12 @@ $(function () {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
 			}
 		},
+		/**
+		 * Shifts all hidden-cards to the end of the container to standardise the card sizes
+		 */
 		shiftCardRow: function () {
 			let l = 0;
 			for (l = 0; l < 5; l++) {
-				//$('.hidden-card')[l].detach().appendChild(Config.dealsContainer);
 				Config.dealsContainer.appendChild($('.hidden-card')[0]);
 			}
 		},

--- a/deals-add.js
+++ b/deals-add.js
@@ -100,6 +100,19 @@ $(function () {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
 			}
 		},
+
+		addCardRow: function () {
+			let l = 0;
+			for (l = 0; l > 4; l++) {
+				Config.dealsContainer.appendChild(Config.dealsContainer.lastChild);
+			}
+		},
+		removeCardRow: function () {
+			let k = 0;
+			for (k = $('.deal-card').length; k > ($('.deal-card').length - 4); k--) {
+				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
+			}
+		},
 		/**
 		* Prevents background scrolling on desktop
 		*/
@@ -193,6 +206,7 @@ $(function () {
 			// there will already be one card on the page, so for subsequent data entries, create a card before populating
 			if (cardNumber !== 0) {
 				RatesDealsHandler.createNewCard();
+				RatesDealsHandler.removeCardRow();
 			}
 			// make the first card on the page visible
 			$('.deal-card')[0].style.display = "block";
@@ -299,6 +313,8 @@ $(function () {
 					for (cardNumber = Config.offset; dataEntry < response.data.length && Config.hasMore; cardNumber++ , dataEntry++) {
 						RatesDealsHandler.populateDeals(response, cardNumber, dataEntry);
 					}
+					RatesDealsHandler.addCardRow();
+
 					// checks if there are more deals that can be loaded for infinite scroll
 					Config.hasMore = response.hasMore;
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -100,17 +100,10 @@ $(function () {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
 			}
 		},
-		addCardRow: function () {
+		shiftCardRow: function () {
 			let l = 0;
-			for (l = 1; l > 6; l++) {
-				Config.dealsContainer.appendChild($('.hidden-card')[0]);
-				$('.hidden-card')[l+1].style.display = "block";
-			}
-		},
-		removeCardRow: function () {
-			let k = 0;
-			for (k = 1; k < 6; k++) {
-				Config.dealsContainer.removeChild($('.hidden-card')[k]);
+			for (l = 0; l > 5; l++) {
+				$('.hidden-card')[l].detach().appendTo(Config.dealsContainer);
 			}
 		},
 		/**
@@ -206,7 +199,6 @@ $(function () {
 			// there will already be one card on the page, so for subsequent data entries, create a card before populating
 			if (cardNumber !== 0) {
 				RatesDealsHandler.createNewCard();
-				RatesDealsHandler.removeCardRow();
 			}
 			// make the first card on the page visible
 			$('.deal-card')[0].style.display = "block";
@@ -313,8 +305,8 @@ $(function () {
 					for (cardNumber = Config.offset; dataEntry < response.data.length && Config.hasMore; cardNumber++ , dataEntry++) {
 						RatesDealsHandler.populateDeals(response, cardNumber, dataEntry);
 					}
-					RatesDealsHandler.addCardRow();
-					
+					RatesDealsHandler.shiftCardRow();
+
 					// checks if there are more deals that can be loaded for infinite scroll
 					Config.hasMore = response.hasMore;
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -149,8 +149,8 @@ $(function () {
 			}
 
 			// update banner link to redirect user to normal feed
-			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
 		},
 		/**
 		 * Closes the error modal, update the address bar and enable scrolling
@@ -337,8 +337,8 @@ $(function () {
 						$('.bottom-banner')[0].style.display = "none";				
 
 						// update banner link so that the app opens at product page
-						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
-						$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[0].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[1].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 
 						// check if ios or android and update link accordingly
 						RatesDealsHandler.checkOS();
@@ -415,8 +415,8 @@ $(function () {
 			}
 
 			// initiate banner links
-			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
 
 			// check if ios or android and update link accordingly
 			RatesDealsHandler.checkOS();

--- a/deals-add.js
+++ b/deals-add.js
@@ -100,6 +100,7 @@ $(function () {
 			for (n = 0; n < 5; n++) {
 				Config.dealsContainer.insertBefore($('.hidden-card')[4], Config.dealsContainer.firstChild);
 			}
+			Config.dealsContainer.insertBefore($('.deal-card')[0], Config.dealsContainer.firstChild);
 			let j = 0;
 			for (j = $('.deal-card').length; j > 1; j--) {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);

--- a/deals-add.js
+++ b/deals-add.js
@@ -354,7 +354,10 @@ $(function () {
 				let hasSmartBanner = "false";
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
-					hasSmartBanner = window.innerHeight - 50 > $(window).innerHeight();
+					// hasSmartBanner = window.innerHeight > $(window).innerHeight() - 50;
+					if (window.innerHeight > $(window).innerHeight()) {
+						RatesDealsHandler.toggleError();
+					}
 					var app = {
 						launchApp: function () {
 							setTimeout(function () {

--- a/deals-add.js
+++ b/deals-add.js
@@ -374,7 +374,6 @@ $(function () {
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
-							RatesDealsHandler.getProductModal(parseInt(qs.productId));
 						},
 					};
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -124,6 +124,33 @@ $(function () {
 				$('.error-bg')[0].style.display = "flex";
 			}
 		},
+		handleCloseProductModal: function () {
+			// close modal
+			RatesDealsHandler.toggleModal();
+
+			// update address bar
+			RatesDealsHandler.getDeals(Config.currentCategory);
+
+			// Remove listener to disable scroll
+			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+
+			// hide top banner
+			$('.top-banner')[0].style.display = "none";
+
+			// update banner link to redirect user to normal feed
+			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
+		},
+		handleCloseErrorModal: function () {
+			// close alert
+			RatesDealsHandler.toggleError();
+
+			// update address bar
+			window.history.pushState({ urlPath: '/deals-copy?category=daily' }, "", '/deals-copy?category=daily');
+
+			// Remove listener to disable scroll
+			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+		},
 		/**
 		* Populate deal cards with information fetched from RateS endpoint
 		*
@@ -373,7 +400,6 @@ $(function () {
 		RatesDealsHandler.resetFeed();
 		Config.currentCategory = 'Daily'
 		RatesDealsHandler.getDeals(Config.currentCategory);
-
 	});
 
 	$('.price-drop-button')[0].addEventListener("click", function () {
@@ -389,25 +415,11 @@ $(function () {
 	});
 
 	$(".product-close-button")[0].addEventListener("click", function () {
-		// close modal
-		RatesDealsHandler.toggleModal();
-
-		// update address bar
-		RatesDealsHandler.getDeals(Config.currentCategory);
-
-		// Remove listener to disable scroll
-		window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+		RatesDealsHandler.handleCloseProductModal();
 	});
 
 	$(".error-close-button")[0].addEventListener("click", function () {
-		// close alert
-		RatesDealsHandler.toggleError();
-
-		// update address bar
-		window.history.pushState({ urlPath: '/deals-copy?category=daily' }, "", '/deals-copy?category=daily');
-
-		// Remove listener to disable scroll
-		window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+		RatesDealsHandler.handleCloseErrorModal();
 	});
 
 	// When users press back, reinitiate

--- a/deals-add.js
+++ b/deals-add.js
@@ -319,7 +319,10 @@ $(function () {
 
 						// make both banners appear
 						$('.top-banner')[0].style.display = "block";
-						$('.bottom-banner')[0].style.display = "block";
+
+						if ($('.top-banner')[0].style.visibility === 'hidden') {
+							$('.bottom-banner')[0].style.display = "block";
+						}						
 
 						// update banner link so that the app opens at product page
 						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;

--- a/deals-add.js
+++ b/deals-add.js
@@ -357,7 +357,7 @@ $(function () {
 							var now = new Date().valueOf();
 							setTimeout(function () {
 									if (new Date().valueOf() - now > 100) return;
-									app.openWebApp();
+									RatesDealsHandler.app.openWebApp();
 							}, 25);
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
 						},

--- a/deals-add.js
+++ b/deals-add.js
@@ -320,6 +320,7 @@ $(function () {
 						// update banner link so that the app opens at product page
 						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 						$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[2].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 
 						// check if ios or android
 						$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';

--- a/deals-add.js
+++ b/deals-add.js
@@ -102,7 +102,7 @@ $(function () {
 		},
 		shiftCardRow: function () {
 			let l = 0;
-			for (l = 0; l > 5; l++) {
+			for (l = 0; l < 5; l++) {
 				$('.hidden-card')[l].detach().appendTo(Config.dealsContainer);
 			}
 		},

--- a/deals-add.js
+++ b/deals-add.js
@@ -100,19 +100,19 @@ $(function () {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
 			}
 		},
-		/*
 		addCardRow: function () {
 			let l = 0;
-			for (l = 0; l > 4; l++) {
-				Config.dealsContainer.appendChild(Config.dealsContainer.lastChild);
+			for (l = 1; l > 6; l++) {
+				Config.dealsContainer.appendChild($('.hidden-card')[0]);
+				$('.hidden-card')[l+1].style.display = "block";
 			}
 		},
 		removeCardRow: function () {
 			let k = 0;
-			for (k = $('.deal-card').length; k > ($('.deal-card').length - 4); k--) {
-				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
+			for (k = 1; k < 6; k++) {
+				Config.dealsContainer.removeChild($('.hidden-card')[k]);
 			}
-		},*/
+		},
 		/**
 		* Prevents background scrolling on desktop
 		*/
@@ -206,6 +206,7 @@ $(function () {
 			// there will already be one card on the page, so for subsequent data entries, create a card before populating
 			if (cardNumber !== 0) {
 				RatesDealsHandler.createNewCard();
+				RatesDealsHandler.removeCardRow();
 			}
 			// make the first card on the page visible
 			$('.deal-card')[0].style.display = "block";
@@ -312,7 +313,8 @@ $(function () {
 					for (cardNumber = Config.offset; dataEntry < response.data.length && Config.hasMore; cardNumber++ , dataEntry++) {
 						RatesDealsHandler.populateDeals(response, cardNumber, dataEntry);
 					}
-
+					RatesDealsHandler.addCardRow();
+					
 					// checks if there are more deals that can be loaded for infinite scroll
 					Config.hasMore = response.hasMore;
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -371,9 +371,7 @@ $(function () {
 					var app = {
 						launchApp: function () {
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
-							setTimeout(function () {
-								RatesDealsHandler.getProductModal(parseInt(qs.productId));
-							}, 25);
+							RatesDealsHandler.getProductModal(parseInt(qs.productId));
 						},
 					};
 
@@ -422,7 +420,7 @@ $(function () {
 		RatesDealsHandler.toggleModal();
 
 		// update address bar
-		window.history.pushState({ urlPath: '/deals-copy?category=daily' }, "", '/deals-copy?category=daily');
+		RatesDealsHandler.getDeals(Config.currentCategory);
 
 		// Remove listener to disable scroll
 		window.removeEventListener('scroll', RatesDealsHandler.noscroll);

--- a/deals-add.js
+++ b/deals-add.js
@@ -355,7 +355,7 @@ $(function () {
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
 					// hasSmartBanner = window.innerHeight > $(window).innerHeight() - 50;
-					if (window.innerHeight > $(window).innerHeight()) {
+					if (window.innerHeight < $(window).innerHeight() - 50) {
 						RatesDealsHandler.toggleError();
 					}
 					var app = {

--- a/deals-add.js
+++ b/deals-add.js
@@ -353,7 +353,7 @@ $(function () {
 				let hasSmartBanner = "false";
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
-					hasSmartBanner = window.innerHeight !== $(window).innerHeight();
+					hasSmartBanner = window.innerHeight < $(window).innerHeight() < 50 ;
 					var app = {
 						launchApp: function () {
 							setTimeout(function () {

--- a/deals-add.js
+++ b/deals-add.js
@@ -353,6 +353,7 @@ $(function () {
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
 					$('meta[name=apple-itunes-app]').attr('app-argument', 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId='+ qs.productId);
+					RatesDealsHandler.getProductModal(parseInt(qs.productId));
 					/*var app = {
 						launchApp: function () {
 							setTimeout(function () {

--- a/deals-add.js
+++ b/deals-add.js
@@ -350,14 +350,18 @@ $(function () {
 				const webkit = !!ua.match(/WebKit/i);
 				// Detect if user is currently using safari web browser
 				const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+				let hasSmartBanner = "false";
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
+					hasSmartBanner = window.innerHeight !== $(window).innerHeight();
 					var app = {
 						launchApp: function () {
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
+							if (!hasSmartBanner) {
+								window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
+							}
 						},
 					};
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -371,6 +371,9 @@ $(function () {
 					var app = {
 						launchApp: function () {
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
+							setTimeout(function () {
+								RatesDealsHandler.getProductModal(parseInt(qs.productId));
+							}, 25);
 							RatesDealsHandler.getProductModal(parseInt(qs.productId));
 						},
 					};

--- a/deals-add.js
+++ b/deals-add.js
@@ -103,7 +103,8 @@ $(function () {
 		shiftCardRow: function () {
 			let l = 0;
 			for (l = 0; l < 5; l++) {
-				$('.hidden-card')[l].detach().appendTo(Config.dealsContainer);
+				//$('.hidden-card')[l].detach().appendChild(Config.dealsContainer);
+				Config.dealsContainer.appendChild($('.hidden-card')[0]);
 			}
 		},
 		/**

--- a/deals-add.js
+++ b/deals-add.js
@@ -354,24 +354,19 @@ $(function () {
 				if (iOSSafari) { // if in safari
 					var app = {
 						launchApp: function () {
-							var now = new Date().valueOf();
 							setTimeout(function () {
-									if (new Date().valueOf() - now > 3000) {
-										return;
-									}
-									window.location.replace("itms-apps://itunes.apple.com/sg/app/rates-mobile-app-by-ratex/id1350096340?mt=8");
+								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct/+productId="+ qs.productId);
 						},
 					};
 
 					app.launchApp();
-					RatesDealsHandler.getProductModal(parseInt(qs.productId));
 				}
 				else if (ua.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/)) { // if in other mobile browsers
 					var app = {
 						launchApp: function () {
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct/+productId="+ qs.productId);
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
@@ -379,7 +374,6 @@ $(function () {
 					};
 
 					app.launchApp();
-					RatesDealsHandler.getProductModal(parseInt(qs.productId));
 				}
 				else { // if on desktop
 					RatesDealsHandler.getProductModal(parseInt(qs.productId));

--- a/deals-add.js
+++ b/deals-add.js
@@ -357,7 +357,7 @@ $(function () {
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct/+productId="+ qs.productId);
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
 						},
 					};
 
@@ -366,7 +366,7 @@ $(function () {
 				else if (ua.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/)) { // if in other mobile browsers
 					var app = {
 						launchApp: function () {
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct/+productId="+ qs.productId);
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);

--- a/deals-add.js
+++ b/deals-add.js
@@ -117,9 +117,11 @@ $(function () {
 			if (mode === 'noscroll') {
 				window.scrollTo(0, 0);
 				$('.deals-page-body')[0].style.overflowY = 'hidden';
+				$('.deals-page-body')[0].style.overflow = 'hidden';
 			}
 			else {
 			$('.deals-page-body')[0].style.overflowY = 'visible';
+			$('.deals-page-body')[0].style.overflow = 'visible';
 			}
 		},
 		/**

--- a/deals-add.js
+++ b/deals-add.js
@@ -357,7 +357,7 @@ $(function () {
 							var now = new Date().valueOf();
 							setTimeout(function () {
 									if (new Date().valueOf() - now > 3000) return;
-									RatesDealsHandler.app.openWebApp();
+									this.openWebApp();
 							}, 25);
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
 						},

--- a/deals-add.js
+++ b/deals-add.js
@@ -316,7 +316,7 @@ $(function () {
 				// takes the data array from response and populate each new card with the information of each entry in this array
 				.done(function (response) {
 					// sets address bar with parameters
-					window.history.pushState({ urlPath: '/deals-copy?category=' + Config.currentCategory }, "", '/deals-copy?category=' + Config.currentCategory);
+					window.history.pushState({ urlPath: '/rates/deals?category=' + Config.currentCategory }, "", '/rates/deals?category=' + Config.currentCategory);
 
 					// make first card on page visible
 					Config.dealsContainer.firstChild.style.display = 'block';

--- a/deals-add.js
+++ b/deals-add.js
@@ -386,7 +386,9 @@ $(function () {
 				branch.init('key_live_lpr2fkDgbAPf4QEMFMreWeppBxkw0l2O', function(err, data) {
 					console.log(err, data); 
 				});
-				console.log(data.has_app);
+				if (data.has_app) {
+					RatesDealsHandler.toggleError();
+				}
 
 				RatesDealsHandler.getProductModal(parseInt(qs.productId));
 			}

--- a/deals-add.js
+++ b/deals-add.js
@@ -321,7 +321,8 @@ $(function () {
 					Config.isFetchingDeals = false;
 				})
 		},
-		displayBanners: function () {
+		displayBanners: function (productId) {
+			RatesDealsHandler.checkOS();
 			if (!Config.isIOS && !Config.isAndroid) {
 				$('.product-details-header')[0].innerHTML = 'NOT IOS NOR ANDROID';
 				// banner don't appear
@@ -341,7 +342,6 @@ $(function () {
 				$('.open-app-button')[1].href = 'ratesbyrate://+productId=' + productId;
 
 				// check if ios or android and update link accordingly
-				RatesDealsHandler.checkOS();
 				if (Config.isAndroid) {
 					$('.product-details-header')[0].innerHTML = 'THIS IS ANDROID';
 					$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
@@ -391,7 +391,7 @@ $(function () {
 						RatesDealsHandler.populateModal(response);
 
 						// display banners as necessary
-						RatesDealsHandler.displayBanners();
+						RatesDealsHandler.displayBanners(productId);
 					}
 
 				})

--- a/deals-add.js
+++ b/deals-add.js
@@ -9,6 +9,7 @@ $(function () {
 		isFetchingDeals: false,
 		wasBottomBannerClosed: false,
 		isAndroid: false,
+		isIOS: false,
 	};
 
 	let RatesDealsHandler = {
@@ -188,8 +189,8 @@ $(function () {
 		 */
 		checkOS: function () {
 			const ua = window.navigator.userAgent;
-			const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
-			Config.isAndroid = !iOS;
+			Config.isIOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
+			Config.isAndroid = !!ua.match(/android/i);
 		},
 		/**
 		* Populate deal cards with information fetched from RateS endpoint
@@ -320,6 +321,37 @@ $(function () {
 					Config.isFetchingDeals = false;
 				})
 		},
+		displayBanners: function () {
+			if (!Config.isIOS && !Config.isAndroid) {
+				// banner don't appear
+				$('.top-banner')[0].style.visibility = "none";
+				$('.bottom-banner')[0].style.visibility = "none";
+			}
+			else {
+				$('.top-banner')[0].style.visibility = "visible";
+				$('.bottom-banner')[0].style.visibility = "visible";
+
+				// default keep top banner visible and bottom banner hidden, switch in A/B test (google optimize)
+				$('.top-banner')[0].style.display = "block";
+				$('.bottom-banner')[0].style.display = "none";
+
+				// update banner link so that the app opens at product page
+				$('.open-app-button')[0].href = 'ratesbyrate://+productId=' + productId;
+				$('.open-app-button')[1].href = 'ratesbyrate://+productId=' + productId;
+
+				// check if ios or android and update link accordingly
+				RatesDealsHandler.checkOS();
+				if (Config.isAndroid) {
+					$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
+					$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
+				}
+				else if (Config.isIOS) {
+					$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+					$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+				}
+			}
+			
+		},
 		/**
 		* Fetch deal from RateS endpoint and populate the product modal with them
 		*
@@ -355,24 +387,8 @@ $(function () {
 						// populate data
 						RatesDealsHandler.populateModal(response);
 
-						// default keep top banner visible and bottom banner hidden, switch in A/B test (google optimize)
-						$('.top-banner')[0].style.display = "block";
-						$('.bottom-banner')[0].style.display = "none";
-
-						// update banner link so that the app opens at product page
-						$('.open-app-button')[0].href = 'ratesbyrate://+productId=' + productId;
-						$('.open-app-button')[1].href = 'ratesbyrate://+productId=' + productId;
-
-						// check if ios or android and update link accordingly
-						RatesDealsHandler.checkOS();
-						if (Config.isAndroid) {
-							$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
-							$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
-						}
-						else {
-							$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
-							$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
-						}
+						// display banners as necessary
+						RatesDealsHandler.displayBanners();
 					}
 
 				})

--- a/deals-add.js
+++ b/deals-add.js
@@ -447,7 +447,7 @@ $(function () {
 		* If category in address is not 'Daily', set the respective category tab as active
 		*/
 		setCurrentButton: function () {
-			$('.daily-button')[0].classList.remove("w--current");
+			$('.price-drop-button')[0].classList.remove("w--current");
 			if (Config.currentCategory === "Price Drops") {
 				$('.price-drop-button')[0].classList.add("w--current");
 			}

--- a/deals-add.js
+++ b/deals-add.js
@@ -158,8 +158,8 @@ $(function () {
 			}
 
 			// update banner link to redirect user to normal feed
-			$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'ratesbyrate://+';
+			$('.open-app-button')[1].href = 'ratesbyrate://+';
 		},
 		/**
 		 * Closes the error modal, update the address bar and enable scrolling
@@ -180,8 +180,8 @@ $(function () {
 			}
 
 			// update banner link to redirect user to normal feed
-			$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'ratesbyrate://+';
+			$('.open-app-button')[1].href = 'ratesbyrate://+';
 		},
 		/**
 		 * Check the OS that the user is on and set Config.isAndroid to true if it is detected to not be iOS
@@ -360,8 +360,8 @@ $(function () {
 						$('.bottom-banner')[0].style.display = "none";
 
 						// update banner link so that the app opens at product page
-						$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
-						$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[0].href = 'ratesbyrate://+productId=' + productId;
+						$('.open-app-button')[1].href = 'ratesbyrate://+productId=' + productId;
 
 						// check if ios or android and update link accordingly
 						RatesDealsHandler.checkOS();
@@ -438,8 +438,8 @@ $(function () {
 			}
 
 			// initiate banner links
-			$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'ratesbyrate://+';
+			$('.open-app-button')[1].href = 'ratesbyrate://+';
 
 			// check if ios or android and update link accordingly
 			RatesDealsHandler.checkOS();

--- a/deals-add.js
+++ b/deals-add.js
@@ -149,8 +149,8 @@ $(function () {
 			}
 
 			// update banner link to redirect user to normal feed
-			$('.open-app-button')[0].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
 		},
 		/**
 		 * Closes the error modal, update the address bar and enable scrolling
@@ -168,7 +168,7 @@ $(function () {
 		/**
 		 * Check the OS that the user is on and set Config.isAndroid to true if it is detected to not be iOS
 		 */
-		checkOS: function() {
+		checkOS: function () {
 			const ua = window.navigator.userAgent;
 			const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
 			Config.isAndroid = !iOS;
@@ -333,16 +333,17 @@ $(function () {
 						// populate data
 						RatesDealsHandler.populateModal(response);
 
+						// default keep top banner visible and bottom banner hidden, switch in A/B test (google optimize)
 						$('.top-banner')[0].style.display = "block";
-						$('.bottom-banner')[0].style.display = "none";				
+						$('.bottom-banner')[0].style.display = "none";
 
 						// update banner link so that the app opens at product page
-						$('.open-app-button')[0].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
-						$('.open-app-button')[1].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 
 						// check if ios or android and update link accordingly
 						RatesDealsHandler.checkOS();
-						if(Config.isAndroid) {
+						if (Config.isAndroid) {
 							$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 							$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 						}
@@ -415,12 +416,12 @@ $(function () {
 			}
 
 			// initiate banner links
-			$('.open-app-button')[0].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
-			$('.open-app-button')[1].href = 'exp://d7-viz.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
 
 			// check if ios or android and update link accordingly
 			RatesDealsHandler.checkOS();
-			if(Config.isAndroid) {
+			if (Config.isAndroid) {
 				$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 				$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 			}
@@ -477,9 +478,7 @@ $(function () {
 
 	// When users press back, reinitiate
 	window.addEventListener('popstate', function (event) {
-
 		RatesDealsHandler.initiate();
-
 	}, false);
 
 	RatesDealsHandler.initiate();

--- a/deals-add.js
+++ b/deals-add.js
@@ -7,6 +7,7 @@ $(function () {
 		offset: 0,
 		hasMore: 'true',
 		isFetchingDeals: false,
+		wasBottomBannerClosed: false,
 	};
 
 	let RatesDealsHandler = {
@@ -136,6 +137,11 @@ $(function () {
 
 			// hide top banner
 			$('.top-banner')[0].style.display = "none";
+
+			// if bottom-banner was not close previously, open it
+			if(!Config.wasBottomBannerClosed) {
+				$('.bottom-banner')[0].style.display = "block";
+			}
 
 			// update banner link to redirect user to normal feed
 			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
@@ -420,6 +426,10 @@ $(function () {
 
 	$(".error-close-button")[0].addEventListener("click", function () {
 		RatesDealsHandler.handleCloseErrorModal();
+	});
+
+	$('.bottom-banner-close-button')[0].addEventListener("click", function () {
+		Config.wasBottomBannerClosed = true;
 	});
 
 	// When users press back, reinitiate

--- a/deals-add.js
+++ b/deals-add.js
@@ -326,8 +326,8 @@ $(function () {
 			if (!Config.isIOS && !Config.isAndroid) {
 				$('.product-details-header')[0].innerHTML = 'NOT IOS NOR ANDROID';
 				// banner don't appear
-				$('.top-banner')[0].style.visibility = "none";
-				$('.bottom-banner')[0].style.visibility = "none";
+				$('.top-banner')[0].style.visibility = "hidden";
+				$('.bottom-banner')[0].style.visibility = "hidden";
 			}
 			else {
 				$('.top-banner')[0].style.visibility = "visible";
@@ -343,12 +343,10 @@ $(function () {
 
 				// check if ios or android and update link accordingly
 				if (Config.isAndroid) {
-					$('.product-details-header')[0].innerHTML = 'THIS IS ANDROID';
 					$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 					$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 				}
 				else if (Config.isIOS) {
-					$('.product-details-header')[0].innerHTML = 'THIS IS IOS';
 					$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 					$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 				}

--- a/deals-add.js
+++ b/deals-add.js
@@ -117,11 +117,11 @@ $(function () {
 			if (mode === 'noscroll') {
 				window.scrollTo(0, 0);
 				$('.deals-page-body')[0].style.overflowY = 'hidden';
-				$('.deals-page-body')[0].style.overflow = 'hidden';
+				$('.body-div')[0].style.overflow = 'hidden';
 			}
 			else {
 			$('.deals-page-body')[0].style.overflowY = 'visible';
-			$('.deals-page-body')[0].style.overflow = 'visible';
+			$('.body-div')[0].style.overflow = 'visible';
 			}
 		},
 		/**

--- a/deals-add.js
+++ b/deals-add.js
@@ -352,18 +352,16 @@ $(function () {
 				const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
-					$('meta[name=apple-itunes-app]').attr('app-argument', 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId='+ qs.productId);
-					RatesDealsHandler.getProductModal(parseInt(qs.productId));
-					/*var app = {
+					var app = {
 						launchApp: function () {
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=" + qs.productId);
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
 						},
 					};
 
-					app.launchApp();*/
+					app.launchApp();
 				}
 				else if (ua.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/)) { // if in other mobile browsers
 					var app = {

--- a/deals-add.js
+++ b/deals-add.js
@@ -323,7 +323,7 @@ $(function () {
 		},
 		displayBanners: function () {
 			if (!Config.isIOS && !Config.isAndroid) {
-				console.log("NOT IOS NOR ANDROID");
+				$('.product-details-header')[0].innerHTML = 'NOT IOS NOR ANDROID';
 				// banner don't appear
 				$('.top-banner')[0].style.visibility = "none";
 				$('.bottom-banner')[0].style.visibility = "none";
@@ -343,12 +343,12 @@ $(function () {
 				// check if ios or android and update link accordingly
 				RatesDealsHandler.checkOS();
 				if (Config.isAndroid) {
-					$('.text-block-111')[0].innerHTML = 'THIS IS ANDROID';
+					$('.product-details-header')[0].innerHTML = 'THIS IS ANDROID';
 					$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 					$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 				}
 				else if (Config.isIOS) {
-					$('.text-block-111')[0].innerHTML = 'THIS IS IOS';
+					$('.product-details-header')[0].innerHTML = 'THIS IS IOS';
 					$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 					$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 				}

--- a/deals-add.js
+++ b/deals-add.js
@@ -352,16 +352,17 @@ $(function () {
 				const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
-					var app = {
+					$('meta[name=apple-itunes-app]').attr('app-argument', 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId='+ qs.productId);
+					/*var app = {
 						launchApp: function () {
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=" + qs.productId);
 						},
 					};
 
-					app.launchApp();
+					app.launchApp();*/
 				}
 				else if (ua.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/)) { // if in other mobile browsers
 					var app = {
@@ -443,4 +444,5 @@ $(function () {
 	}, false);
 
 	RatesDealsHandler.initiate();
+	
 });

--- a/deals-add.js
+++ b/deals-add.js
@@ -139,7 +139,7 @@ $(function () {
 			$('.top-banner')[0].style.display = "none";
 
 			// if bottom-banner was not close previously, open it
-			if(!Config.wasBottomBannerClosed) {
+			if (!Config.wasBottomBannerClosed) {
 				$('.bottom-banner')[0].style.display = "block";
 			}
 
@@ -391,6 +391,14 @@ $(function () {
 			if (qs.productId !== undefined) {
 				RatesDealsHandler.getProductModal(parseInt(qs.productId));
 			}
+
+			// initiate banner links
+			$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+';
+
+			// check if ios or android
+			$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+			$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 		}
 	};
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -190,7 +190,7 @@ $(function () {
 		checkOS: function () {
 			const ua = window.navigator.userAgent;
 			Config.isIOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
-			Config.isAndroid = !!ua.match(/android/i);
+			Config.isAndroid = !!ua.match(/Android/i);
 		},
 		/**
 		* Populate deal cards with information fetched from RateS endpoint
@@ -323,6 +323,7 @@ $(function () {
 		},
 		displayBanners: function () {
 			if (!Config.isIOS && !Config.isAndroid) {
+				console.log("NOT IOS NOR ANDROID");
 				// banner don't appear
 				$('.top-banner')[0].style.visibility = "none";
 				$('.bottom-banner')[0].style.visibility = "none";
@@ -342,10 +343,12 @@ $(function () {
 				// check if ios or android and update link accordingly
 				RatesDealsHandler.checkOS();
 				if (Config.isAndroid) {
+					$('.text-block-111')[0].innerHTML = 'THIS IS ANDROID';
 					$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 					$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
 				}
 				else if (Config.isIOS) {
+					$('.text-block-111')[0].innerHTML = 'THIS IS IOS';
 					$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 					$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 				}

--- a/deals-add.js
+++ b/deals-add.js
@@ -283,6 +283,10 @@ $(function () {
 
 						// populate data
 						RatesDealsHandler.populateModal(response);
+
+						// update banner link so that the app opens at product page
+						$(open-app-button)[0].href = "exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ productId;
+						$(open-app-button)[1].href = "exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ productId;
 					}
 
 				})

--- a/deals-add.js
+++ b/deals-add.js
@@ -324,7 +324,6 @@ $(function () {
 		displayBanners: function (productId) {
 			RatesDealsHandler.checkOS();
 			if (!Config.isIOS && !Config.isAndroid) {
-				$('.product-details-header')[0].innerHTML = 'NOT IOS NOR ANDROID';
 				// banner don't appear
 				$('.top-banner')[0].style.visibility = "hidden";
 				$('.bottom-banner')[0].style.visibility = "hidden";

--- a/deals-add.js
+++ b/deals-add.js
@@ -257,7 +257,7 @@ $(function () {
 		* @param {String}		productId		the id of the product to request from RateS endpoint
 		*/
 		getProductModal: function (productId) {
-
+			console.log("open product view modal");
 			$.ajax({
 				method: 'GET',
 				url: 'https://ratex.co/store/api/products/' + productId

--- a/deals-add.js
+++ b/deals-add.js
@@ -354,7 +354,7 @@ $(function () {
 				let hasSmartBanner = "false";
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
-					hasSmartBanner = window.innerHeight < $(window).innerHeight() < 50;
+					hasSmartBanner = window.innerHeight - 50 > $(window).innerHeight();
 					var app = {
 						launchApp: function () {
 							setTimeout(function () {

--- a/deals-add.js
+++ b/deals-add.js
@@ -164,6 +164,15 @@ $(function () {
 
 			// Remove listener to disable scroll
 			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+
+			// if bottom-banner was not close previously, open it
+			if (!Config.wasBottomBannerClosed) {
+				$('.bottom-banner')[0].style.display = "block";
+			}
+
+			// update banner link to redirect user to normal feed
+			$('.open-app-button')[0].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
+			$('.open-app-button')[1].href = 'exp://rb-grv.jessidew95.ratex-mobile.exp.direct:80/+';
 		},
 		/**
 		 * Check the OS that the user is on and set Config.isAndroid to true if it is detected to not be iOS
@@ -319,6 +328,8 @@ $(function () {
 					if (response.data.id !== productId) {
 						// error
 						RatesDealsHandler.toggleError();
+						$('.top-banner')[0].style.display = "none";
+						$('.bottom-banner')[0].style.display = "none";
 					} else {
 
 						// sets address bar with parameters

--- a/deals-add.js
+++ b/deals-add.js
@@ -351,12 +351,12 @@ $(function () {
 				const webkit = !!ua.match(/WebKit/i);
 				// Detect if user is currently using safari web browser
 				const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
-				let hasSmartBanner = "false";
+				let hasSmartBanner = false;
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
 					// hasSmartBanner = window.innerHeight > $(window).innerHeight() - 50;
 					if (window.innerHeight < $(window).innerHeight() - 50) {
-						RatesDealsHandler.toggleError();
+						hasSmartBanner = true;
 					}
 					var app = {
 						launchApp: function () {

--- a/deals-add.js
+++ b/deals-add.js
@@ -344,7 +344,7 @@ $(function () {
 
 			// check for specified product to display
 			if (qs.productId !== undefined) {
-				const ua = window.navigator.userAgent;
+				/*const ua = window.navigator.userAgent;
 				// Detect if user is on iOS
 				const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
 				const webkit = !!ua.match(/WebKit/i);
@@ -353,14 +353,14 @@ $(function () {
 				let hasSmartBanner = "false";
 				// if yes, check for cookie
 				if (iOSSafari) { // if in safari
-					hasSmartBanner = window.innerHeight < $(window).innerHeight() < 50 ;
+					hasSmartBanner = window.innerHeight < $(window).innerHeight() < 50;
 					var app = {
 						launchApp: function () {
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
 							if (!hasSmartBanner) {
-								window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
+								window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=" + qs.productId);
 							}
 						},
 					};
@@ -370,7 +370,7 @@ $(function () {
 				else if (ua.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/)) { // if in other mobile browsers
 					var app = {
 						launchApp: function () {
-							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId="+ qs.productId);
+							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=" + qs.productId);
 							setTimeout(function () {
 								RatesDealsHandler.getProductModal(parseInt(qs.productId));
 							}, 25);
@@ -382,6 +382,13 @@ $(function () {
 				else { // if on desktop
 					RatesDealsHandler.getProductModal(parseInt(qs.productId));
 				}
+				*/
+				branch.init('key_live_lpr2fkDgbAPf4QEMFMreWeppBxkw0l2O', function(err, data) {
+					console.log(err, data); 
+				});
+				console.log(data.has_app);
+
+				RatesDealsHandler.getProductModal(parseInt(qs.productId));
 			}
 		}
 	};
@@ -447,5 +454,5 @@ $(function () {
 	}, false);
 
 	RatesDealsHandler.initiate();
-	
+
 });

--- a/deals-add.js
+++ b/deals-add.js
@@ -117,7 +117,8 @@ $(function () {
 		},
 		/**
 		* Prevents background scrolling on desktop
-		* @param {Boolean}  mode		
+		*
+		* @param {Boolean}  mode	if set to true, disable scroll. Else, enable scroll.
 		*/
 		setNoScroll: function (mode) {
 			if (mode) {
@@ -201,7 +202,7 @@ $(function () {
 			$('.open-app-button')[1].href = 'ratesbyrate://+';
 		},
 		/**
-		 * Check the OS that the user is on and set Config.isAndroid to true if it is detected to not be iOS
+		 * Check the OS that the user is on and set Config.isAndroid or Config.isIOS to true as appropriate
 		 */
 		checkOS: function () {
 			const ua = window.navigator.userAgent;
@@ -337,6 +338,11 @@ $(function () {
 					Config.isFetchingDeals = false;
 				})
 		},
+		/**
+		* Displays all the appropriate banners and update banner links according to user's OS
+		*
+		* @param {String}		productId		the id of the product to link in the deep link
+		*/
 		displayBanners: function (productId) {
 			RatesDealsHandler.checkOS();
 			if (!Config.isIOS && !Config.isAndroid) {

--- a/deals-add.js
+++ b/deals-add.js
@@ -344,7 +344,8 @@ $(function () {
 
 			// check for specified product to display
 			if (qs.productId !== undefined) {
-				/*const ua = window.navigator.userAgent;
+
+				const ua = window.navigator.userAgent;
 				// Detect if user is on iOS
 				const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
 				const webkit = !!ua.match(/WebKit/i);
@@ -382,15 +383,6 @@ $(function () {
 				else { // if on desktop
 					RatesDealsHandler.getProductModal(parseInt(qs.productId));
 				}
-				*/
-				branch.init('key_live_lpr2fkDgbAPf4QEMFMreWeppBxkw0l2O', function(err, data) {
-					console.log(err, data); 
-				});
-				if (data.has_app) {
-					RatesDealsHandler.toggleError();
-				}
-
-				RatesDealsHandler.getProductModal(parseInt(qs.productId));
 			}
 		}
 	};

--- a/deals-add.js
+++ b/deals-add.js
@@ -357,14 +357,10 @@ $(function () {
 							var now = new Date().valueOf();
 							setTimeout(function () {
 									if (new Date().valueOf() - now > 3000) return;
-									this.openWebApp();
+									window.location.replace("itms-apps://itunes.apple.com/sg/app/rates-mobile-app-by-ratex/id1350096340?mt=8");
 							}, 25);
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");
 						},
-
-						openWebApp: function () {
-							window.location.replace("itms-apps://itunes.apple.com/sg/app/rates-mobile-app-by-ratex/id1350096340?mt=8");
-						}
 					};
 
 					app.launchApp();

--- a/deals-add.js
+++ b/deals-add.js
@@ -113,8 +113,14 @@ $(function () {
 		/**
 		* Prevents background scrolling on desktop
 		*/
-		noscroll: function () {
-			window.scrollTo(0, 0);
+		setScroll: function (mode) {
+			if (mode === 'noscroll') {
+				window.scrollTo(0, 0);
+				$('.deals-page-body')[0].style.overflowY = 'hidden';
+			}
+			else {
+			$('.deals-page-body')[0].style.overflowY = 'visible';
+			}
 		},
 		/**
 		* Toggles between showing and hiding modal
@@ -148,7 +154,8 @@ $(function () {
 			RatesDealsHandler.getDeals(Config.currentCategory);
 
 			// Remove listener to disable scroll
-			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+			//window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+			RatesDealsHandler.setScroll('scroll');
 
 			// hide top banner
 			$('.top-banner')[0].style.display = "none";
@@ -173,7 +180,8 @@ $(function () {
 			window.history.pushState({ urlPath: '/deals-copy?category=daily' }, "", '/deals-copy?category=daily');
 
 			// Remove listener to disable scroll
-			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+			//window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+			RatesDealsHandler.setScroll('scroll');
 
 			// if bottom-banner was not close previously, open it
 			if (!Config.wasBottomBannerClosed) {
@@ -371,6 +379,7 @@ $(function () {
 					if (response.data.id !== productId) {
 						// error
 						RatesDealsHandler.toggleError();
+						RatesDealsHandler.setScroll('noscroll');
 						$('.top-banner')[0].style.display = "none";
 						$('.bottom-banner')[0].style.display = "none";
 					} else {
@@ -379,7 +388,8 @@ $(function () {
 						window.history.pushState({ urlPath: '/deals-copy?productId=' + productId }, "", '/deals-copy?productId=' + productId);
 
 						// add listener to disable scroll
-						window.addEventListener('scroll', RatesDealsHandler.noscroll);
+						// window.addEventListener('scroll', RatesDealsHandler.noscroll);
+						RatesDealsHandler.setScroll('noscroll');
 
 						// display modal
 						RatesDealsHandler.toggleModal();

--- a/deals-add.js
+++ b/deals-add.js
@@ -8,6 +8,7 @@ $(function () {
 		hasMore: 'true',
 		isFetchingDeals: false,
 		wasBottomBannerClosed: false,
+		isAndroid: false,
 	};
 
 	let RatesDealsHandler = {
@@ -156,6 +157,11 @@ $(function () {
 
 			// Remove listener to disable scroll
 			window.removeEventListener('scroll', RatesDealsHandler.noscroll);
+		},
+		checkOS: function() {
+			const ua = window.navigator.userAgent;
+			const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i) || !!ua.match(/iPod/i);
+			Config.isAndroid = !iOS;
 		},
 		/**
 		* Populate deal cards with information fetched from RateS endpoint
@@ -324,9 +330,16 @@ $(function () {
 						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 						$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 
-						// check if ios or android
-						$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
-						$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+						// check if ios or android and update link accordingly
+						RatesDealsHandler.checkOS();
+						if(Config.isAndroid) {
+							$('.install-app-button')[0].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
+							$('.install-app-button')[1].href = 'https://play.google.com/store/apps/details?id=com.rate.rates';
+						}
+						else {
+							$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+							$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+						}
 					}
 
 				})

--- a/deals-add.js
+++ b/deals-add.js
@@ -96,6 +96,10 @@ $(function () {
 			Config.offset = 0;
 			Config.hasMore = true;
 			$('.deal-card')[0].style.display = "none";
+			let n = 0;
+			for (n = 0; n < 5; n++) {
+				container.insertBefore($('.hidden-card')[4], container.firstChild);
+			}
 			let j = 0;
 			for (j = $('.deal-card').length; j > 1; j--) {
 				Config.dealsContainer.removeChild(Config.dealsContainer.lastChild);
@@ -112,9 +116,10 @@ $(function () {
 		},
 		/**
 		* Prevents background scrolling on desktop
+		* @param {Boolean}  mode		
 		*/
-		setScroll: function (mode) {
-			if (mode === 'noscroll') {
+		setNoScroll: function (mode) {
+			if (mode) {
 				window.scrollTo(0, 0);
 				$('.deals-page-body')[0].style.overflowY = 'hidden';
 				$('.body-div')[0].style.overflow = 'hidden';
@@ -157,7 +162,7 @@ $(function () {
 
 			// Remove listener to disable scroll
 			//window.removeEventListener('scroll', RatesDealsHandler.noscroll);
-			RatesDealsHandler.setScroll('scroll');
+			RatesDealsHandler.setNoScroll(false);
 
 			// hide top banner
 			$('.top-banner')[0].style.display = "none";
@@ -183,7 +188,7 @@ $(function () {
 
 			// Remove listener to disable scroll
 			//window.removeEventListener('scroll', RatesDealsHandler.noscroll);
-			RatesDealsHandler.setScroll('scroll');
+			RatesDealsHandler.setNoScroll(false);
 
 			// if bottom-banner was not close previously, open it
 			if (!Config.wasBottomBannerClosed) {
@@ -381,7 +386,7 @@ $(function () {
 					if (response.data.id !== productId) {
 						// error
 						RatesDealsHandler.toggleError();
-						RatesDealsHandler.setScroll('noscroll');
+						RatesDealsHandler.setNoScroll(true);
 						$('.top-banner')[0].style.display = "none";
 						$('.bottom-banner')[0].style.display = "none";
 					} else {
@@ -391,7 +396,7 @@ $(function () {
 
 						// add listener to disable scroll
 						// window.addEventListener('scroll', RatesDealsHandler.noscroll);
-						RatesDealsHandler.setScroll('noscroll');
+						RatesDealsHandler.setNoScroll(true);
 
 						// display modal
 						RatesDealsHandler.toggleModal();

--- a/deals-add.js
+++ b/deals-add.js
@@ -492,7 +492,7 @@ $(function () {
 				$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 			}
 
-			$('.top-banner').style.display = "none";
+			$('.top-banner')[0].style.display = "none";
 		}
 	};
 

--- a/deals-add.js
+++ b/deals-add.js
@@ -317,10 +317,13 @@ $(function () {
 						// populate data
 						RatesDealsHandler.populateModal(response);
 
+						// make both banners appear
+						$('.top-banner')[0].style.display = "block";
+						$('.bottom-banner')[0].style.display = "block";
+
 						// update banner link so that the app opens at product page
 						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 						$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
-						$('.open-app-button')[2].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 
 						// check if ios or android
 						$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';

--- a/deals-add.js
+++ b/deals-add.js
@@ -98,7 +98,7 @@ $(function () {
 			$('.deal-card')[0].style.display = "none";
 			let n = 0;
 			for (n = 0; n < 5; n++) {
-				container.insertBefore($('.hidden-card')[4], container.firstChild);
+				Config.dealsContainer.insertBefore($('.hidden-card')[4], Config.dealsContainer.firstChild);
 			}
 			let j = 0;
 			for (j = $('.deal-card').length; j > 1; j--) {

--- a/deals-add.js
+++ b/deals-add.js
@@ -322,6 +322,9 @@ $(function () {
 
 						if ($('.top-banner')[0].style.visibility === 'hidden') {
 							$('.bottom-banner')[0].style.display = "block";
+						} 
+						else {
+							$('.bottom-banner')[0].style.display = "none";
 						}						
 
 						// update banner link so that the app opens at product page

--- a/deals-add.js
+++ b/deals-add.js
@@ -285,12 +285,12 @@ $(function () {
 						RatesDealsHandler.populateModal(response);
 
 						// update banner link so that the app opens at product page
-						$(open-app-button)[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
-						$(open-app-button)[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.open-app-button')[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
 
 						// check if ios or android
-						$(install-app-button)[0].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
-						$(install-app-button)[1].href = 'exp://8n-s2q.jessidew95.ratex-mobile.exp.direct:80/+productId=' + productId;
+						$('.install-app-button')[0].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
+						$('.install-app-button')[1].href = 'itms-apps://itunes.apple.com/app/apple-store/id1350096340';
 					}
 
 				})

--- a/deals-add.js
+++ b/deals-add.js
@@ -356,7 +356,7 @@ $(function () {
 						launchApp: function () {
 							var now = new Date().valueOf();
 							setTimeout(function () {
-									if (new Date().valueOf() - now > 500) return;
+									if (new Date().valueOf() - now > 3000) return;
 									RatesDealsHandler.app.openWebApp();
 							}, 25);
 							window.location.replace("exp://8n-s2q.jessidew95.ratex-mobile.exp.direct");


### PR DESCRIPTION
Created product modal view, the new functions make use of some of the same functions as the add-deals function.

Users will enter ratex.co/deals?productId=358
the modal will appear and show the product with id 358
Once users close, they will not be able to reopen this modal view from the deals page unless they press back. (Since this is only for sharing)

Fixes #6 