### PR TITLE
Remove background color

### DIFF
--- a/shopathon-deals/singlesdaysales.js
+++ b/shopathon-deals/singlesdaysales.js
@@ -127,7 +127,7 @@ class DealCell {
     newElement.innerHTML = `
       <div class="cards-wraper" style="margin-bottom: 36px;">
         <img
-          style="cursor: pointer; object-fit: cover;"
+          style="cursor: pointer; object-fit: cover; background: none;"
           src="${this.imageUrl}"
           onClick="window.open('${this.itemUrl}')"
           class="link-block-38 w-inline-block"


### PR DESCRIPTION
Remove background color of `<img>` as the transparent background of img will cause the placeholder to seep through